### PR TITLE
Fix encryption issue due to required Buffer module in crypto.js

### DIFF
--- a/src/crypto.js
+++ b/src/crypto.js
@@ -2,7 +2,6 @@ const BSVABI = require('../bsvabi/bsvabi');
 const twetchPublicKey = '022f01e5e15cca351daff3843fb70f3c2f0a1bdd05e5af888a67784ef3e10a2a01';
 const ecies = require('../bsvabi/bsv/ecies');
 const Crypto = require('../shared-helpers/crypto');
-const Buffer = require('buffer/').Buffer;
 global.window = global;
 
 class TwetchCrypto {


### PR DESCRIPTION
Issues with the BSV library versions were a red herring. True issue was that a required buffer module in crypto.js was treating the Buffer being decrypted as an object, failing type checking in the bsv library.

Fix is to remove the Buffer import, and rely on Node's standard Buffer implementation.